### PR TITLE
Support loading multiple jqueries

### DIFF
--- a/src/WidgetName/lib/jquery-wrapper.js
+++ b/src/WidgetName/lib/jquery-wrapper.js
@@ -1,0 +1,7 @@
+var amd = window.define.amd;
+delete window.define.amd;
+define(['jquery-1.11.2.min'], function(jquery) { 
+        window.define.amd = amd;
+            return jquery.noConflict( true );
+});
+

--- a/src/WidgetName/widget/WidgetName.js
+++ b/src/WidgetName/widget/WidgetName.js
@@ -21,11 +21,11 @@
 define([
     'dojo/_base/declare', 'mxui/widget/_WidgetBase', 'dijit/_TemplatedMixin',
     'mxui/dom', 'dojo/dom', 'dojo/query', 'dojo/dom-prop', 'dojo/dom-geometry', 'dojo/dom-class', 'dojo/dom-style', 'dojo/dom-construct', 'dojo/_base/array', 'dojo/_base/lang', 'dojo/text', 'dojo/html', 'dojo/_base/event',
-    'WidgetName/lib/jquery-1.11.2.min', 'dojo/text!WidgetName/widget/template/WidgetName.html'
+    'WidgetName/lib/jquery-wrapper', 'dojo/text!WidgetName/widget/template/WidgetName.html'
 ], function (declare, _WidgetBase, _TemplatedMixin, dom, dojoDom, domQuery, domProp, domGeom, domClass, domStyle, domConstruct, dojoArray, lang, text, html, event, _jQuery, widgetTemplate) {
     'use strict';
 
-    var $ = jQuery.noConflict(true);
+    var $ = jQuery;
     
     // Declare widget's prototype.
     return declare('WidgetName.widget.WidgetName', [_WidgetBase, _TemplatedMixin], {


### PR DESCRIPTION
So, the problem here is that jquery is a library that uses define (AMD
style), but passes it an explicit string which is non unique, "jquery".
This means that if you load different jquery versions they will *all*
try to define themselves as "jquery".

This wrapper removes the amd attribute from define, which is used by
jquery to figure out whether to register amd style or not.

See line 10311:
http://code.jquery.com/jquery-1.11.3.js

Yes, this is still a little hacky: other libraries that try to properly
support AMD may check for this var :S