### PR TITLE
Missing reference dom node

### DIFF
--- a/src/WidgetName/widget/WidgetName.js
+++ b/src/WidgetName/widget/WidgetName.js
@@ -44,6 +44,7 @@ define([
         templateString: widgetTemplate,
 
         // DOM elements
+        inputNodes: null,
         colorSelectNode: null,
         colorInputNode: null,
         infoTextNode: null,


### PR DESCRIPTION
https://github.com/mendix/AppStoreWidgetBoilerplate/blob/master/src/WidgetName/widget/template/WidgetName.html
has 4 data-dojo-attach-point

This is not a functional bug; just  more thorough.