### PR TITLE
required does not need an empty function

### DIFF
--- a/src/WidgetName/widget/WidgetName.js
+++ b/src/WidgetName/widget/WidgetName.js
@@ -258,6 +258,4 @@ define([
     });
 });
 
-require(["WidgetName/widget/WidgetName"], function() {
-    "use strict";
-});
+require(["WidgetName/widget/WidgetName"]);


### PR DESCRIPTION
js lint start to complain, the documentation allows to requires without a callback function.

Anyway; I am interested to know why this line is necessary?