### PR TITLE
Fix dojo place call with the attributes in the wrong order.

### DIFF
--- a/src/WidgetName/widget/WidgetName.js
+++ b/src/WidgetName/widget/WidgetName.js
@@ -209,7 +209,7 @@ define([
                 "class": "alert alert-danger",
                 "innerHTML": message
             });
-            dojoConstruct.place(this.domNode, this._alertDiv);
+            dojoConstruct.place(this._alertDiv, this.domNode);
         },
 
         // Add a validation.


### PR DESCRIPTION
Shouldn't the place call have the attributes the other way around?