### PR TITLE
Need of _unsubscribe in uninitialize

### DIFF
--- a/src/WidgetName/widget/WidgetName.js
+++ b/src/WidgetName/widget/WidgetName.js
@@ -109,6 +109,7 @@ define([
         uninitialize: function () {
           logger.debug(this.id + ".uninitialize");
             // Clean up listeners, helper objects, etc. There is no need to remove listeners added with this.connect / this.subscribe / this.own.
+            this._unsubscribe();
         },
 
         // We want to stop events on a mobile device


### PR DESCRIPTION
Do we need to unsubscribe to the handlers in unintialise?
As we don't use; this.connect / this.subscribe / this.own
