### PR TITLE
Make use of WidgetBase#subscribe to make sure that subscriptions are …

### DIFF
--- a/src/WidgetName/widget/WidgetName.js
+++ b/src/WidgetName/widget/WidgetName.js
@@ -226,7 +226,7 @@ define([
         _unsubscribe: function () {
           if (this._handles) {
               dojoArray.forEach(this._handles, function (handle) {
-                  mx.data.unsubscribe(handle);
+                  this.unsubscribe(handle);
               });
               this._handles = [];
           }
@@ -240,14 +240,14 @@ define([
 
             // When a mendix object exists create subscribtions.
             if (this._contextObj) {
-                var objectHandle = mx.data.subscribe({
+                var objectHandle = this.subscribe({
                     guid: this._contextObj.getGuid(),
                     callback: dojoLang.hitch(this, function (guid) {
                         this._updateRendering();
                     })
                 });
 
-                var attrHandle = mx.data.subscribe({
+                var attrHandle = this.subscribe({
                     guid: this._contextObj.getGuid(),
                     attr: this.backgroundColor,
                     callback: dojoLang.hitch(this, function (guid, attr, attrValue) {
@@ -255,7 +255,7 @@ define([
                     })
                 });
 
-                var validationHandle = mx.data.subscribe({
+                var validationHandle = this.subscribe({
                     guid: this._contextObj.getGuid(),
                     val: true,
                     callback: dojoLang.hitch(this, this._handleValidation)


### PR DESCRIPTION
…cleaned up on uninitialization of the widget

As per https://apidocs.mendix.com/6/client/mx.data.html#.subscribe, widgets are highly recommended to use WidgetBase#subscribe because, I quote, "[it] makes sure the subscription is automatically removed when the widget is destroyed".

There is a comment in unitialize() that hints at this:

"// Clean up listeners, helper objects, etc. There is no need to remove listeners added with this.connect / this.subscribe / this.own."

However, _resetSubscriptions() and _unsubscribe() used mx.data.[un]subscribe instead of this.[un]subscribe. Small change, big difference, as we noticed with one of our new widgets, where _updateRendering() was called for widgets that were in fact (being) destroyed.