### PR TITLE
Add nanoflow option to xsd

### DIFF
--- a/xsd/widget.xsd
+++ b/xsd/widget.xsd
@@ -63,6 +63,7 @@
             <xs:enumeration value="image"/>
             <xs:enumeration value="integer"/>
             <xs:enumeration value="microflow"/>
+            <xs:enumeration value="nanoflow"/>
             <xs:enumeration value="object"/>
             <xs:enumeration value="string"/>
             <xs:enumeration value="translatableString"/>


### PR DESCRIPTION
With 7.13 calling nanoflows from widgets will be possible, this extends custom widget xsd to allow `nanoflow` option as property type. Should be merged when 7.13 is released.